### PR TITLE
Enable GUI support in GHCi by default on MacOS X

### DIFF
--- a/wxcore/src/haskell/Graphics/UI/WXCore.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore.hs
@@ -62,14 +62,21 @@ import Graphics.UI.WXCore.Layout
 import Graphics.UI.WXCore.Image
 import Graphics.UI.WXCore.OpenGL
 
+import Graphics.UI.WXCore.GHCiSupport
+
 -- | Start the event loop. Takes an initialisation action as argument.
 -- Except for 'run', the functions in the WXH library can only be called
 -- from this intialisation action or from event handlers, or otherwise bad
 -- things will happen :-)
 run :: IO a -> IO ()
 run init
-  = do appOnInit (do wxcAppInitAllImageHandlers
+  = do enableGUI
+       appOnInit (do wxcAppInitAllImageHandlers
                      init
                      return ())
        performGC
        performGC
+
+
+
+

--- a/wxcore/src/haskell/Graphics/UI/WXCore/GHCiSupport.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/GHCiSupport.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Graphics.UI.WXCore.GHCiSupport(enableGUI) where
+-- GHCi support on MacOS X
+-- TODO: preprocessor to make it conditional on the platform
+
+import Data.Int
+import Foreign
+
+type ProcessSerialNumber = Int64
+
+foreign import ccall "GetCurrentProcess" getCurrentProcess :: Ptr ProcessSerialNumber -> IO Int16
+foreign import ccall "_CGSDefaultConnection" cgsDefaultConnection :: IO ()
+foreign import ccall "CPSEnableForegroundOperation" cpsEnableForegroundOperation :: Ptr ProcessSerialNumber -> IO ()
+foreign import ccall "CPSSignalAppReady" cpsSignalAppReady :: Ptr ProcessSerialNumber -> IO ()
+foreign import ccall "CPSSetFrontProcess" cpsSetFrontProcess :: Ptr ProcessSerialNumber -> IO ()
+
+enableGUI = alloca $ \psn -> do
+    getCurrentProcess psn
+    cgsDefaultConnection
+    cpsEnableForegroundOperation psn
+    cpsSignalAppReady psn
+    cpsSetFrontProcess psn

--- a/wxcore/src/haskell/Graphics/UI/WXCore/GHCiSupport.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/GHCiSupport.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ForeignFunctionInterface, CPP #-}
 module Graphics.UI.WXCore.GHCiSupport(enableGUI) where
 -- GHCi support on MacOS X
 -- TODO: preprocessor to make it conditional on the platform
+
+#if darwin_HOST_OS
 
 import Data.Int
 import Foreign
@@ -14,9 +16,17 @@ foreign import ccall "CPSEnableForegroundOperation" cpsEnableForegroundOperation
 foreign import ccall "CPSSignalAppReady" cpsSignalAppReady :: Ptr ProcessSerialNumber -> IO ()
 foreign import ccall "CPSSetFrontProcess" cpsSetFrontProcess :: Ptr ProcessSerialNumber -> IO ()
 
+enableGUI :: IO ()
 enableGUI = alloca $ \psn -> do
     getCurrentProcess psn
     cgsDefaultConnection
     cpsEnableForegroundOperation psn
     cpsSignalAppReady psn
     cpsSetFrontProcess psn
+
+#else
+
+enableGUI :: IO ()
+enableGUI = return ()
+
+#endif

--- a/wxcore/wxcore.cabal
+++ b/wxcore/wxcore.cabal
@@ -60,6 +60,12 @@ library
     Graphics.UI.WXCore.WxcObject
     Graphics.UI.WXCore.WxcTypes
 
+  other-modules:
+    Graphics.UI.WXCore.GHCiSupport
+
+  frameworks:
+    Carbon
+
   build-depends:
     bytestring,
     filepath,


### PR DESCRIPTION
This patch bakes the old `EnableGUI.hs` solution right into the wxcore package. This works because GHC packages may reference external libraries that GHCi will link in.

Note: The new GHCiSupport.hs module probably needs to be wrapped in #ifdefs.

Note: People need to be reminded to use the `ghci -fno-ghci-sandbox` flag if they want to use wx from GHCi.

This patch does not address the issue that wx is prone to crashes when used twice from GHCi.
