### PR TITLE
Fix building WXWIDGETS_2_8 with GHC 7.6.1

### DIFF
--- a/wxcore/src/haskell/Graphics/UI/WXCore/Events.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/Events.hs
@@ -237,6 +237,7 @@ import System.Environment( getProgName, getArgs )
 import Foreign.StablePtr
 import Foreign.Ptr
 import Foreign.C.String
+import Foreign.C.Types
 import Foreign.Marshal.Alloc
 import Foreign.Marshal.Array
 import Foreign.Marshal.Utils

--- a/wxcore/wxcore.cabal
+++ b/wxcore/wxcore.cabal
@@ -209,7 +209,7 @@ library
     build-depends:
       array >= 0.2 && < 0.5,
       base >= 4 && < 5,
-      containers >= 0.2 && < 0.5
+      containers >= 0.2 && < 0.6
   else
     build-depends:
       array >= 0.1 && < 0.3,

--- a/wxdirect/src/CompileClasses.hs
+++ b/wxdirect/src/CompileClasses.hs
@@ -100,6 +100,7 @@ compileClassesFile showIgnore moduleRoot moduleClassTypesName moduleName outputF
                                 , ""
                                 , "import qualified Data.ByteString as B (ByteString, useAsCStringLen)"
                                 , "import qualified Data.ByteString.Lazy as LB (ByteString, length, unpack)"
+                                , "import Foreign.C.Types"
                                 , "import System.IO.Unsafe( unsafePerformIO )"
                                 , "import " ++ moduleRoot ++ "WxcTypes"
                                 , "import " ++ moduleRoot ++ moduleClassTypesName

--- a/wxdirect/src/ParseEiffel.hs
+++ b/wxdirect/src/ParseEiffel.hs
@@ -20,6 +20,7 @@ import Text.ParserCombinators.Parsec.Language
 import Types
 
 import System.Environment ( getEnv )
+import System.IO.Error    (catchIOError)
 
 {-----------------------------------------------------------------------------------------
    Testing
@@ -33,7 +34,7 @@ test
 
 getDefaultEiffelFiles :: IO [FilePath]
 getDefaultEiffelFiles
-  = do wxwin <- getEnv "WXWIN" `catch` \err -> return ""
+  = do wxwin <- getEnv "WXWIN" `catchIOError` \err -> return ""
        return [wxwin ++ "/wxc/include/wxc_defs.e"
               ,wxwin ++ "/wxc/ewxw/eiffel/spec/r_2_4/wx_defs.e"]
 

--- a/wxdirect/wxdirect.cabal
+++ b/wxdirect/wxdirect.cabal
@@ -68,7 +68,7 @@ executable wxdirect
   if flag(splitBase)
     build-depends:
         base       >= 4     && < 5,
-        containers >= 0.2   && < 0.5
+        containers >= 0.2   && < 0.6
   else
     build-depends:
         base       >= 3     && < 4,

--- a/wxdirect/wxdirect.cabal
+++ b/wxdirect/wxdirect.cabal
@@ -1,5 +1,5 @@
 name:         wxdirect
-version:      0.13.1.2
+version:      0.13.1.3
 license:      BSD3
 license-file: LICENSE
 author:       Daan Leijen


### PR DESCRIPTION
GHC 7.6.1 can't build WXWIDGETS_2_8 branch's wxdirect and wxcore. I made change to fix this problem.

I splited my changes into two part, their are general change ( shelarcy@5149eb3ba177efd305a243597adbd6090beef8c0 ) and WXWIDGETS_2_8 specific one. So, I think that we can pick general change to fix HEAD's same problem.

I already uploaded fixed version to HackageDB. Becase HackageDB's version didn't reflect c31ca7c11c974b05d4c0e7501d7f8d9b10d66e4f change, too. That causes building problem.
- http://sourceforge.net/tracker/?func=detail&atid=536845&aid=3572834&group_id=73133
