### PR TITLE
Fixed image creation from bytestring bug

### DIFF
--- a/wxc/src/cpp/eljgrid.cpp
+++ b/wxc/src/cpp/eljgrid.cpp
@@ -140,6 +140,17 @@ EWXWEXPORT(void*,wxGridCellChoiceEditor_Ctor)(int count,void* choices,bool allow
 	return (void*)new wxGridCellChoiceEditor (count, items, allowOthers);
 }
 
+EWXWEXPORT(void*,wxGridCellNumberRenderer_Ctor)()
+{
+	return (void*)new wxGridCellNumberRenderer();
+}
+
+EWXWEXPORT(void*,wxGridCellAutoWrapStringRenderer_Ctor)()
+{
+	return (void*)new wxGridCellAutoWrapStringRenderer();
+}
+
+
 EWXWEXPORT(void*,wxGridCellAttr_Ctor)()
 {
 	return (void*)new wxGridCellAttr();
@@ -1157,6 +1168,12 @@ EWXWEXPORT(int,wxGrid_GetSelectedCols)(wxGrid* self,void* _arr)
 	return arr.GetCount();
 }
 	
+EWXWEXPORT(void,wxGrid_GetCellSize)(wxGrid* self,int r, int c, int* sr, int* sc){
+	self->GetCellSize(r,c,sr,sc);
+}
+EWXWEXPORT(void,wxGrid_SetCellSize)(wxGrid* self,int r, int c, int sr, int sc){
+	self->SetCellSize(r,c,sr,sc);
+}
 
 
 EWXWEXPORT(void*,ELJGridTable_Create)(void* self,void* _EifGetNumberRows,void* _EifGetNumberCols,void* _EifGetValue,void* _EifSetValue,void* _EifIsEmptyCell,void* _EifClear,void* _EifInsertRows,void* _EifAppendRows,void* _EifDeleteRows,void* _EifInsertCols,void* _EifAppendCols,void* _EifDeleteCols,void* _EifSetRowLabelValue,void* _EifSetColLabelValue,void* _EifGetRowLabelValue,void* _EifGetColLabelValue)

--- a/wxc/src/cpp/eljimage.cpp
+++ b/wxc/src/cpp/eljimage.cpp
@@ -30,6 +30,7 @@ EWXWEXPORT(size_t,wxImage_ConvertToByteString)(wxImage* self,int type,char* data
 	wxMemoryOutputStream out;
 	self->SaveFile(out, type);
 	size_t len = out.GetLength();
+	if( !data ) return len;
         return out.CopyTo(data, len);
 }
 
@@ -38,6 +39,7 @@ EWXWEXPORT(size_t,wxImage_ConvertToLazyByteString)(wxImage* self,int type,char* 
 	wxMemoryOutputStream out;
 	self->SaveFile(out, type);
 	size_t len = out.GetLength();
+	if( !data ) return len;
         return out.CopyTo(data, len);
 }
 

--- a/wxc/src/cpp/eljscrolledwindow.cpp
+++ b/wxc/src/cpp/eljscrolledwindow.cpp
@@ -18,6 +18,11 @@ EWXWEXPORT(void*,wxScrolledWindow_GetTargetWindow)(void* self)
 	return (void*)((wxScrolledWindow*)self)->GetTargetWindow();
 }
 	
+EWXWEXPORT(void,wxScrolledWindow_ShowScrollbars)(void* self,int showh,int showv)
+{
+	((wxScrolledWindow*)self)->ShowScrollbars((wxScrollbarVisibility)showh,(wxScrollbarVisibility)showv);
+}
+
 EWXWEXPORT(void,wxScrolledWindow_SetScrollbars)(void* self,int pixelsPerUnitX,int pixelsPerUnitY,int noUnitsX,int noUnitsY,int xPos,int yPos,bool noRefresh)
 {
 	((wxScrolledWindow*)self)->SetScrollbars(pixelsPerUnitX, pixelsPerUnitY, noUnitsX, noUnitsY, xPos, yPos, noRefresh);

--- a/wxc/src/cpp/eljsplitterwindow.cpp
+++ b/wxc/src/cpp/eljsplitterwindow.cpp
@@ -97,5 +97,15 @@ EWXWEXPORT(int,wxSplitterWindow_GetMinimumPaneSize)(void* self)
 {
 	return ((wxSplitterWindow*)self)->GetMinimumPaneSize();
 }
+
+EWXWEXPORT(double,wxSplitterWindow_GetSashGravity)(void* self)
+{
+	return ((wxSplitterWindow*)self)->GetSashGravity();
+}
+	
+EWXWEXPORT(void,wxSplitterWindow_SetSashGravity)(void* self, double gravity)
+{
+	return ((wxSplitterWindow*)self)->SetSashGravity(gravity);
+}
 	
 }

--- a/wxc/src/include/wxc_glue.h
+++ b/wxc/src/include/wxc_glue.h
@@ -2482,6 +2482,8 @@ void       wxGrid_GetSelectionBlockTopLeft(TSelf(wxGrid) _obj, TClassRef(wxGridC
 void       wxGrid_GetSelectionBlockBottomRight(TSelf(wxGrid) _obj, TClassRef(wxGridCellCoordsArray) _arr);
 TArrayLen  wxGrid_GetSelectedRows(TSelf(wxGrid) _obj, TArrayIntOutVoid _arr);
 TArrayLen  wxGrid_GetSelectedCols(TSelf(wxGrid) _obj, TArrayIntOutVoid _arr);
+void       wxGrid_GetCellSize(TSelf(wxGrid) _obj, int row, int col, TSizeOut(srow,scol));
+void       wxGrid_SetCellSize(TSelf(wxGrid) _obj, int row, int col, TSize(srow,scol));
 
 /* wxGridCellAttr */
 TClassDef(wxGridCellAttr)
@@ -2560,6 +2562,11 @@ TClass(wxGridCellNumberEditor)  wxGridCellNumberEditor_Ctor( int min, int max );
 
 /* wxGridCellNumberRenderer */
 TClassDefExtend(wxGridCellNumberRenderer,wxGridCellStringRenderer)
+TClass(wxGridCellNumberRenderer)  wxGridCellNumberRenderer_Ctor();
+
+/* wxGridCellAutoWrapStringRenderer */
+TClassDefExtend(wxGridCellAutoWrapStringRenderer,wxGridCellStringRenderer)
+TClass(wxGridCellAutoWrapStringRenderer)  wxGridCellAutoWrapStringRenderer_Ctor();
 
 /* wxGridCellRenderer */
 TClassDefExtend(wxGridCellRenderer,wxGridCellWorker)
@@ -4174,6 +4181,7 @@ void       wxScrolledWindow_Scroll( TSelf(wxScrolledWindow) _obj, TPoint(x_pos,y
 void       wxScrolledWindow_SetScale( TSelf(wxScrolledWindow) _obj, double xs, double ys );
 void       wxScrolledWindow_SetScrollPageSize( TSelf(wxScrolledWindow) _obj, int orient, int pageSize );
 void       wxScrolledWindow_SetScrollbars( TSelf(wxScrolledWindow) _obj, int pixelsPerUnitX, int pixelsPerUnitY, int noUnitsX, int noUnitsY, int xPos, int yPos, TBool noRefresh );
+void       wxScrolledWindow_ShowScrollbars( TSelf(wxScrolledWindow) _obj, int showh, int showv );
 void       wxScrolledWindow_SetTargetWindow( TSelf(wxScrolledWindow) _obj, TClass(wxWindow) target );
 void       wxScrolledWindow_ViewStart( TSelf(wxScrolledWindow) _obj, TPointOutVoid(_x,_y) );
 
@@ -4417,6 +4425,8 @@ void       wxSplitterWindow_SetSplitMode( TSelf(wxSplitterWindow) _obj, int mode
 TBool      wxSplitterWindow_SplitHorizontally( TSelf(wxSplitterWindow) _obj, TClass(wxWindow) window1, TClass(wxWindow) window2, int sashPosition );
 TBool      wxSplitterWindow_SplitVertically( TSelf(wxSplitterWindow) _obj, TClass(wxWindow) window1, TClass(wxWindow) window2, int sashPosition );
 TBool      wxSplitterWindow_Unsplit( TSelf(wxSplitterWindow) _obj, TClass(wxWindow) toRemove );
+double     wxSplitterWindow_GetSashGravity( TSelf(wxSplitterWindow) _obj );
+void       wxSplitterWindow_SetSashGravity( TSelf(wxSplitterWindow) _obj, double gravity );
 
 /* wxStaticBitmap */
 TClassDefExtend(wxStaticBitmap,wxControl)

--- a/wxcore/src/haskell/Graphics/UI/WXCore/WxcTypes.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/WxcTypes.hs
@@ -723,7 +723,7 @@ withStringResult f
         then return ""
         else withCString (replicate (fromCInt len) ' ') $ \cstr ->
              do f cstr
-                peekCString cstr
+                peekCStringLen (cstr,fromCInt len)
 
 withWStringResult :: (Ptr CWchar -> IO CInt) -> IO String
 withWStringResult f
@@ -746,7 +746,7 @@ withByteStringResult f
         then return $ BC.pack ""
         else withCString (replicate (fromCInt len) ' ') $ \cstr ->
              do f cstr
-                B.packCString cstr
+                B.packCStringLen (cstr,fromCInt len)
 
 withLazyByteStringResult :: (Ptr CChar -> IO CInt) -> IO LB.ByteString
 withLazyByteStringResult f


### PR DESCRIPTION
Fixed imageCreateFromLazyByteString, peek from CString with specified length,
to avoid recognizing zeroes in data as NULL-termination in string
