### PR TITLE
ghc-7.6 updates

### DIFF
--- a/wxcore/src/haskell/Graphics/UI/WXCore/WxcTypes.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/WxcTypes.hs
@@ -91,12 +91,12 @@ module Graphics.UI.WXCore.WxcTypes(
 
             -- ** Primitive types
             -- *** CString
-            , CString, withCString, withStringResult
-            , CWString, withCWString, withWStringResult
+            , CString(..), withCString, withStringResult
+            , CWString(..), withCWString, withWStringResult
             -- *** ByteString
             , withByteStringResult, withLazyByteStringResult
             -- *** CInt
-            , CInt, toCInt, fromCInt, withIntResult
+            , CInt(..), toCInt, fromCInt, withIntResult
             -- *** Word
             , Word
             -- *** 8 bit Word
@@ -104,12 +104,12 @@ module Graphics.UI.WXCore.WxcTypes(
             -- *** 64 bit Integer
             , Int64
             -- *** CDouble
-            , CDouble, toCDouble, fromCDouble, withDoubleResult
+            , CDouble(..), toCDouble, fromCDouble, withDoubleResult
             -- *** CChar
-            , CChar, toCChar, fromCChar, withCharResult
-            , CWchar, toCWchar
+            , CChar(..), toCChar, fromCChar, withCharResult
+            , CWchar(..), toCWchar
             -- *** CBool
-            , CBool, toCBool, fromCBool, withBoolResult
+            , CBool(..), toCBool, fromCBool, withBoolResult
             -- ** Pointers
             , Ptr, ptrNull, ptrIsNull, ptrCast, ForeignPtr, FunPtr, toCFunPtr
             ) where

--- a/wxcore/wxcore.cabal
+++ b/wxcore/wxcore.cabal
@@ -80,7 +80,7 @@ library
     build-depends:
       array >= 0.2 && < 0.5,
       base >= 4 && < 5,
-      containers >= 0.2 && < 0.5
+      containers >= 0.2 && < 0.6
   else
     build-depends:
       array >= 0.1 && < 0.3,

--- a/wxdirect/wxdirect.cabal
+++ b/wxdirect/wxdirect.cabal
@@ -61,16 +61,16 @@ executable wxdirect
     directory,
     parsec     >= 2.1.0 && < 4,
     strict,
-    time       >= 1.0   && < 1.3
+    time       >= 1.0   && < 2
 
   if flag(splitBase)
     build-depends:
         base       >= 4     && < 5,
-        containers >= 0.2   && < 0.5
+        containers >= 0.2   
   else
     build-depends:
         base       >= 3     && < 4,
-        containers >= 0.1   && < 0.3
+        containers >= 0.1   && < 0.6
 
 --  ghc-options: -Wall
   if impl(ghc >= 6.8)


### PR DESCRIPTION
this permits the more recent `containers` library, and takes account of new restrictions on Foreign things which require that constructors be in scope.
