### PR TITLE
Resolves 'CInt' build errors related to FFI type restrictions in GHC 7.6.1

### DIFF
--- a/wxcore/src/haskell/Graphics/UI/WXCore/Events.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/Events.hs
@@ -242,6 +242,7 @@ import System.Environment( getProgName, getArgs )
 import Foreign.StablePtr
 import Foreign.Ptr
 import Foreign.C.String
+import Foreign.C.Types( CInt(..) )
 import Foreign.Marshal.Alloc
 import Foreign.Marshal.Array
 import Foreign.Marshal.Utils


### PR DESCRIPTION
GHC 7.6.1 has restricted newtypes in FFI declarations and trying to build this file will result in errors like this: Unacceptable argument type in foreign declaration: CInt

It can be fixed by simply including the constructor for the 'CInt' type.

Longer description here:
http://hackage.haskell.org/trac/ghc/ticket/5610
