### PR TITLE
send a paint event, otherwise the image won't appear

### DIFF
--- a/samples/contrib/GLCanvas.hs
+++ b/samples/contrib/GLCanvas.hs
@@ -44,6 +44,7 @@ gui = do
 -- show anything!
             , on paintRaw := paintGL glCanvas
             ]
+   repaint f
 
 convWG (WX.Size w h) = (GL.Size (convInt32  w) (convInt32  h))
 convInt32 = fromInteger . toInteger


### PR DESCRIPTION
This problem happens on my mac (Lion 10.8.2) and the solution works.
