### PR TITLE
Build correctly on modern GHC and better error message upon common build failure

### DIFF
--- a/samples/test/UTF8.lhs
+++ b/samples/test/UTF8.lhs
@@ -36,7 +36,7 @@ the Unicode Transformation Format with 8-bit words.
 >     encodeOne, decodeOne,
 >   ) where
 
-> import Char (ord, chr)
+> import Data.Char (ord, chr)
 > import Data.Word (Word8, Word16, Word32)
 > import Data.Bits (Bits, shiftL, shiftR, (.&.), (.|.))
 

--- a/wxc/Setup.hs
+++ b/wxc/Setup.hs
@@ -16,10 +16,19 @@ import System.Directory (createDirectoryIfMissing, doesFileExist, getCurrentDire
 import System.Environment (getEnv)
 import System.Exit (ExitCode (..))
 import System.FilePath.Posix ((</>), (<.>), replaceExtension, takeFileName, dropFileName, addExtension)
+import System.IO (hPutStrLn, stderr)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Process (readProcess)
+import qualified System.Process as Process
+import qualified Control.Exception as E
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+readProcess :: FilePath -> [String] -> String -> IO String
+readProcess cmd args stdin =
+  Process.readProcess cmd args stdin
+  `E.catch` \(E.SomeException err) -> do
+    hPutStrLn stderr $ "readProcess failed: " ++ show err
+    E.throwIO err
 
 main :: IO ()
 main = defaultMainWithHooks simpleUserHooks { confHook = myConfHook, buildHook = myBuildHook, instHook = myInstHook }

--- a/wxcore/src/haskell/Graphics/UI/WXCore/Events.hs
+++ b/wxcore/src/haskell/Graphics/UI/WXCore/Events.hs
@@ -241,6 +241,7 @@ import Data.List( intersperse, findIndex )
 import System.Environment( getProgName, getArgs )
 import Foreign.StablePtr
 import Foreign.Ptr
+import Foreign.C.Types
 import Foreign.C.String
 import Foreign.Marshal.Alloc
 import Foreign.Marshal.Array

--- a/wxcore/wxcore.cabal
+++ b/wxcore/wxcore.cabal
@@ -80,7 +80,7 @@ library
     build-depends:
       array >= 0.2 && < 0.5,
       base >= 4 && < 5,
-      containers >= 0.2 && < 0.5
+      containers >= 0.2 && < 0.6
   else
     build-depends:
       array >= 0.1 && < 0.3,

--- a/wxdirect/src/CompileClasses.hs
+++ b/wxdirect/src/CompileClasses.hs
@@ -101,6 +101,7 @@ compileClassesFile showIgnore moduleRoot moduleClassTypesName moduleName outputF
                                 , "import qualified Data.ByteString as B (ByteString, useAsCStringLen)"
                                 , "import qualified Data.ByteString.Lazy as LB (ByteString, length, unpack)"
                                 , "import System.IO.Unsafe( unsafePerformIO )"
+                                , "import Foreign.C.Types(CInt(..), CWchar(..), CChar(..), CDouble(..))"
                                 , "import " ++ moduleRoot ++ "WxcTypes"
                                 , "import " ++ moduleRoot ++ moduleClassTypesName
                                 , ""

--- a/wxdirect/wxdirect.cabal
+++ b/wxdirect/wxdirect.cabal
@@ -61,12 +61,12 @@ executable wxdirect
     directory,
     parsec     >= 2.1.0 && < 4,
     strict,
-    time       >= 1.0   && < 1.3
+    time       >= 1.0   && < 1.5
 
   if flag(splitBase)
     build-depends:
         base       >= 4     && < 5,
-        containers >= 0.2   && < 0.5
+        containers >= 0.2   && < 0.6
   else
     build-depends:
         base       >= 3     && < 4,


### PR DESCRIPTION
If system lacks "wx-config" in $PATH, then currently the Setup.hs in wxc will just fail silently, swallowing errors. 
I got: "Setup: failed" which is confusing and frustrating.
I added a small patch to log an error about this to make the failure much more self-evident (message about failed invocation of wx-config).

Additionally, wxdirect and wxcore had overly restrictive dependency constraints on time/containers.

Additionally, wxdirect generated FFI declarations that depend on Foreign.C.Types without explicitly importing their data constructors, which is no longer allowed. Similarly, wxcore had such code. Added the necessary imports.
